### PR TITLE
Fixed bug in render-results in step4: No li-tag around first list element

### DIFF
--- a/src/cljs/cljsworkshop/core.cljs
+++ b/src/cljs/cljsworkshop/core.cljs
@@ -25,6 +25,7 @@
   (let [results (js->clj results)]
     (reduce (fn [acc result]
               (str acc "<li>" result "</li>"))
+            ""
             (second results))))
 
 (defn do-jsonp


### PR DESCRIPTION
This looks fine in the html tutorial but is broken in the actual code. In some way it's a good exercise for the reader :-) but I guess it could also confuse the reader. 
